### PR TITLE
Fix duplicate generated class names

### DIFF
--- a/src/main/java/ladysnake/dissolution/common/entity/PossessableEntityFactory.java
+++ b/src/main/java/ladysnake/dissolution/common/entity/PossessableEntityFactory.java
@@ -108,7 +108,7 @@ public class PossessableEntityFactory {
     }
 
     private static String getName(Class baseClass) {
-        return String.format("%s_%s", EntityPossessableImpl.class.getName(), baseClass.getSimpleName());
+        return String.format("%s_%s_%s", EntityPossessableImpl.class.getName(), baseClass.getSimpleName(), baseClass.getName().hashCode());
     }
 
     /**


### PR DESCRIPTION
When using the mods Lycanite and Corvus together with Dissolution, the following error occurs :
```
java.lang.LinkageError: loader (instance of  ladysnake/dissolution/common/entity/PossessableEntityFactory$ASMClassLoader): attempted  duplicate class definition for name: "ladysnake/dissolution/common/entity/EntityPossessableImpl_EntityWendigo"
```

This PR fixes the issue by appending the hashcode of the full base class name (including packages) to the generated name.