### PR TITLE
fixing aether_legacy softdepend (crash)

### DIFF
--- a/changelog.json
+++ b/changelog.json
@@ -31,6 +31,6 @@
         "0.3.10": "All credits for this update goes to sschr15\n- Added the Hardcore option to also be possible in survival.\n- Added a config option to enable said behavior.",
         "0.3.11": "- Version bump for ModWinder support",
         "0.3.12": "- FIXED A BUG!!! When possessing a creeper, spider, or enderman, GUIs work properly.\n  - However, your hotbar will not show up. Already planning on looking into that.",
-        "0.3.13": "- Pyrofab fixed a bug caused when two mobs had the same class name."
+        "0.3.13": "- [@Pyrofab](//github.com/Pyrofab) fixed a bug caused when two mobs had the same class name."
     }
 }

--- a/dependencies.gradle
+++ b/dependencies.gradle
@@ -24,6 +24,9 @@ repositories {
     maven {
         url 'http://maven.jamieswhiteshirt.com/libs-release/'
     }
+	maven {
+        url "https://cursemaven.com"
+    }
 }
 
 dependencies {
@@ -42,7 +45,7 @@ dependencies {
     compileOnly     "potion-core:PotionCore:1.6_for_${mc_version}:src"
     //compileOnly     "epic-siege-mod:EpicSiegeMod:13.163:sources"
     deobfProvided   "journeymap:journeymap:1.12.2:5.5.3"
-    deobfProvided   "the-aether:aether_legacy:${mc_version}:${aether_version}"
+    deobfProvided   "curse.maven:aether_legacy-255308:3280119"
     deobfCompile    "com.jamieswhiteshirt:clothesline-hooks:1.12.2-0.0.1.0"
     compileOnly     "ichunutil:iChunUtil:${mc_version}:${ichunutil_version}"
     compileOnly     "sync:Sync:${mc_version}:${sync_version}"

--- a/gradle.properties
+++ b/gradle.properties
@@ -9,7 +9,7 @@ dissolution_version=0.3.13
 version_nickname=r2
 
 # Workspace
-forge_version=1.12.2-14.23.5.2846
+forge_version=1.12.2-14.23.5.2847
 mcp_version=stable_39
 ladylib_version=2.6.2
 clothesline_hook_version=0.0.1.2

--- a/src/main/java/ladysnake/dissolution/common/compat/AetherLegacyCompat.java
+++ b/src/main/java/ladysnake/dissolution/common/compat/AetherLegacyCompat.java
@@ -1,8 +1,8 @@
 package ladysnake.dissolution.common.compat;
 
-import com.legacy.aether.Aether;
-import com.legacy.aether.AetherConfig;
-import com.legacy.aether.client.gui.inventory.GuiAccessories;
+import com.gildedgames.the_aether.Aether;
+import com.gildedgames.the_aether.AetherConfig;
+import com.gildedgames.the_aether.client.gui.inventory.GuiAccessories;
 import ladylib.compat.EnhancedBusSubscriber;
 import ladysnake.dissolution.common.Ref;
 import ladysnake.dissolution.common.capabilities.CapabilityIncorporealHandler;


### PR DESCRIPTION
When opening the inventory minecraft crashes.

this happens to many older mods that depend on the old url of aether